### PR TITLE
Create PWA scaffold with basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# unraid-pwa
-Unraid PWA is a new PWA client for Unraid
+# Unraid PWA
+
+This project is a statically hosted Progressive Web App for managing Unraid instances.
+It communicates with the Unraid GraphQL interface (see `schema.json`) and stores data locally on the device.
+
+## Development
+
+The application lives in the `src` directory and is built using plain HTML and JavaScript. Tests are located in the `tests` directory and can be executed with:
+
+```bash
+npm test
+```
+
+## Project Structure
+
+- `src/index.html` – main entry point that registers the service worker.
+- `src/main.js` – JavaScript entry module with a placeholder GraphQL fetch helper.
+- `src/sw.js` – service worker providing offline capabilities.
+- `src/manifest.json` – PWA manifest configuration.
+- `tests/` – simple assertion based tests run via Node.
+
+The project is designed to be hosted on GitHub Pages without any server side components.

--- a/agents.md
+++ b/agents.md
@@ -10,3 +10,13 @@ Rules to follow as an agent (please review each time):
 - Always remember our focus on delivering a statically hosted PWA - this must never be broken
 - Always update README and agents.md to reflect the current state of the app. Agents.md should capture any of your concerns or planned next steps.
 
+
+## Current State
+
+A basic PWA scaffold has been created using plain HTML and JavaScript. Service worker registration and a placeholder GraphQL helper are included. Simple Node based tests verify the manifest and exported functions.
+
+## Next Steps
+
+- Implement UI components for interacting with the Unraid GraphQL API.
+- Expand test coverage as features are added.
+- Investigate build tooling for production assets while maintaining static hosting.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "unraid-pwa",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="./manifest.json">
+    <title>Unraid PWA</title>
+</head>
+<body>
+    <h1>Unraid PWA</h1>
+    <div id="app"></div>
+    <script src="./main.js" type="module"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,16 @@
+// Register service worker for offline capabilities
+if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw.js').catch(console.error);
+    });
+}
+
+// Placeholder function to fetch data from Unraid GraphQL interface
+export async function fetchUnraidData(query, fetchFn = fetch) {
+    const response = await fetchFn('/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+    });
+    return response.json();
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Unraid PWA",
+    "short_name": "Unraid",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "description": "A PWA client for managing Unraid instances",
+    "icons": []
+}

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,15 @@
+self.addEventListener('install', (event) => {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+    event.respondWith(
+        caches.match(event.request).then((response) => {
+            return response || fetch(event.request);
+        })
+    );
+});

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { fetchUnraidData } = require('../src/main.js');
+
+async function dummyFetch() {
+  return { json: async () => ({ ok: true }) };
+}
+
+(async () => {
+  try {
+    assert.strictEqual(typeof fetchUnraidData, 'function', 'fetchUnraidData should be a function');
+    const result = fetchUnraidData('query { version }', dummyFetch);
+    assert.ok(result instanceof Promise, 'fetchUnraidData should return a Promise');
+    const data = await result;
+    assert.deepStrictEqual(data, { ok: true });
+    module.exports = true;
+  } catch (err) {
+    console.error(err);
+    module.exports = false;
+  }
+})();

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const manifest = require('../src/manifest.json');
+
+try {
+  assert.strictEqual(manifest.name, 'Unraid PWA');
+  assert.ok(manifest.start_url, 'start_url is required');
+  assert.ok(manifest.display, 'display is required');
+  module.exports = true;
+} catch (err) {
+  console.error(err);
+  module.exports = false;
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+let failed = false;
+
+// run each test file
+fs.readdirSync(__dirname)
+  .filter(f => f.endsWith('.test.js'))
+  .forEach(file => {
+    const result = require(path.join(__dirname, file));
+    if (result === false) {
+      console.error(`Test failed: ${file}`);
+      failed = true;
+    } else {
+      console.log(`Test passed: ${file}`);
+    }
+  });
+
+if (failed) {
+  console.error('Tests failed');
+  process.exit(1);
+} else {
+  console.log('All tests passed');
+}


### PR DESCRIPTION
## Summary
- add initial src files for a static PWA
- add package.json and simple Node-based test runner
- add basic tests covering manifest and GraphQL helper
- update README and AGENTS docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580aa3ca2083329d4d6645305d0083