### PR TITLE
Add settings UI and GraphQL fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ npm test
 ## Project Structure
 
 - `src/index.html` – main entry point that registers the service worker.
-- `src/main.js` – JavaScript entry module with a placeholder GraphQL fetch helper.
+- `src/main.js` – JavaScript entry module with helpers for storing connection settings and querying the Unraid GraphQL API.
 - `src/sw.js` – service worker providing offline capabilities.
 - `src/manifest.json` – PWA manifest configuration.
 - `tests/` – simple assertion based tests run via Node.
 
 The project is designed to be hosted on GitHub Pages without any server side components.
+
+## Usage
+
+Open `index.html` in a browser (or deploy the contents of `src` to GitHub Pages).
+Enter the URL of your Unraid server and an API token in the form at the top of the page.
+These values are saved to `localStorage` on your device and used for subsequent requests.
+After saving, the application will query the server for basic information such as the Unraid version and display the JSON response.

--- a/agents.md
+++ b/agents.md
@@ -13,10 +13,10 @@ Rules to follow as an agent (please review each time):
 
 ## Current State
 
-A basic PWA scaffold has been created using plain HTML and JavaScript. Service worker registration and a placeholder GraphQL helper are included. Simple Node based tests verify the manifest and exported functions.
+The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the new settings logic.
 
 ## Next Steps
 
-- Implement UI components for interacting with the Unraid GraphQL API.
-- Expand test coverage as features are added.
+- Extend the UI to display more data from Unraid (array status, VMs, etc.).
+- Continue expanding test coverage for new features.
 - Investigate build tooling for production assets while maintaining static hosting.

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,12 @@
 </head>
 <body>
     <h1>Unraid PWA</h1>
+    <div id="settings">
+        <label>Host: <input id="host" type="text" placeholder="https://my-unraid"/></label>
+        <label>API Token: <input id="token" type="password"/></label>
+        <button id="saveSettings">Save</button>
+    </div>
+    <pre id="info"></pre>
     <div id="app"></div>
     <script src="./main.js" type="module"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -5,12 +5,60 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
     });
 }
 
-// Placeholder function to fetch data from Unraid GraphQL interface
+// Helpers for persisting connection settings and communicating with the Unraid GraphQL interface
+export function getSettings() {
+    if (typeof localStorage === 'undefined') return { host: '', token: '' };
+    return {
+        host: localStorage.getItem('unraidHost') || '',
+        token: localStorage.getItem('unraidToken') || ''
+    };
+}
+
+export function setSettings({ host, token }) {
+    if (typeof localStorage === 'undefined') return;
+    if (host !== undefined) localStorage.setItem('unraidHost', host);
+    if (token !== undefined) localStorage.setItem('unraidToken', token);
+}
+
 export async function fetchUnraidData(query, fetchFn = fetch) {
-    const response = await fetchFn('/graphql', {
+    const { host, token } = getSettings();
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    const response = await fetchFn(`${host}/graphql`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ query })
     });
     return response.json();
+}
+
+// Simple UI wiring to load settings and display basic info
+function updateInfo() {
+    const el = document.getElementById('info');
+    if (!el) return;
+    fetchUnraidData('query { vars { version } }')
+        .then(data => {
+            el.textContent = JSON.stringify(data, null, 2);
+        })
+        .catch(err => {
+            el.textContent = err.message;
+        });
+}
+
+if (typeof document !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', () => {
+        const { host, token } = getSettings();
+        const hostInput = document.getElementById('host');
+        const tokenInput = document.getElementById('token');
+        if (hostInput) hostInput.value = host;
+        if (tokenInput) tokenInput.value = token;
+        const saveBtn = document.getElementById('saveSettings');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', () => {
+                setSettings({ host: hostInput.value, token: tokenInput.value });
+                updateInfo();
+            });
+        }
+        updateInfo();
+    });
 }

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const { fetchUnraidData, setSettings } = require('../src/main.js');
+
+// minimal localStorage mock
+global.localStorage = {
+  store: {},
+  getItem(key) { return this.store[key]; },
+  setItem(key, val) { this.store[key] = val; }
+};
+
+(async () => {
+  let captured;
+  async function dummyFetch(url, options) {
+    captured = { url, options };
+    return { json: async () => ({ ok: true }) };
+  }
+
+  setSettings({ host: 'http://host', token: 'secret' });
+  const data = await fetchUnraidData('query { vars { version } }', dummyFetch);
+
+  try {
+    assert.deepStrictEqual(data, { ok: true });
+    assert.strictEqual(captured.url, 'http://host/graphql');
+    assert.strictEqual(captured.options.headers['Authorization'], 'Bearer secret');
+    module.exports = true;
+  } catch (err) {
+    console.error(err);
+    module.exports = false;
+  }
+})();


### PR DESCRIPTION
## Summary
- allow configuration of Unraid host and API token
- fetch Unraid version via new helper and display result
- document usage and update project status
- capture connection logic in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580c60a68c8332ba9f0d3f96f53c4c