### PR TITLE
Enable self-signed certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ Open `index.html` in a browser (or deploy the contents of `src` to GitHub Pages)
 Enter the URL of your Unraid server and an API token in the form at the top of the page.
 These values are saved to `localStorage` on your device and used for subsequent requests.
 After saving, the application will query the server for basic information such as the Unraid version and display the JSON response.
+
+### Self-signed certificates
+
+If your Unraid server uses a self-signed TLS certificate you can check the
+"Allow self-signed certificates" option in the settings form. When running in
+Node (for example during tests), this will disable certificate validation so the
+GraphQL requests succeed. Browsers still require you to manually trust the
+certificate the first time you connect.

--- a/agents.md
+++ b/agents.md
@@ -13,7 +13,7 @@ Rules to follow as an agent (please review each time):
 
 ## Current State
 
-The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the new settings logic.
+The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option.
 
 ## Next Steps
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <div id="settings">
         <label>Host: <input id="host" type="text" placeholder="https://my-unraid"/></label>
         <label>API Token: <input id="token" type="password"/></label>
+        <label><input id="allowSelfSigned" type="checkbox"/> Allow self-signed certificates</label>
         <button id="saveSettings">Save</button>
     </div>
     <pre id="info"></pre>

--- a/src/main.js
+++ b/src/main.js
@@ -7,28 +7,35 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
 
 // Helpers for persisting connection settings and communicating with the Unraid GraphQL interface
 export function getSettings() {
-    if (typeof localStorage === 'undefined') return { host: '', token: '' };
+    if (typeof localStorage === 'undefined') return { host: '', token: '', allowSelfSigned: false };
     return {
         host: localStorage.getItem('unraidHost') || '',
-        token: localStorage.getItem('unraidToken') || ''
+        token: localStorage.getItem('unraidToken') || '',
+        allowSelfSigned: localStorage.getItem('unraidAllowSelfSigned') === 'true'
     };
 }
 
-export function setSettings({ host, token }) {
+export function setSettings({ host, token, allowSelfSigned }) {
     if (typeof localStorage === 'undefined') return;
     if (host !== undefined) localStorage.setItem('unraidHost', host);
     if (token !== undefined) localStorage.setItem('unraidToken', token);
+    if (allowSelfSigned !== undefined) localStorage.setItem('unraidAllowSelfSigned', String(allowSelfSigned));
 }
 
 export async function fetchUnraidData(query, fetchFn = fetch) {
-    const { host, token } = getSettings();
+    const { host, token, allowSelfSigned } = getSettings();
     const headers = { 'Content-Type': 'application/json' };
     if (token) headers['Authorization'] = `Bearer ${token}`;
-    const response = await fetchFn(`${host}/graphql`, {
+    const options = {
         method: 'POST',
         headers,
         body: JSON.stringify({ query })
-    });
+    };
+    if (allowSelfSigned && typeof window === 'undefined') {
+        const { Agent } = await import('https');
+        options.agent = new Agent({ rejectUnauthorized: false });
+    }
+    const response = await fetchFn(`${host}/graphql`, options);
     return response.json();
 }
 
@@ -47,15 +54,17 @@ function updateInfo() {
 
 if (typeof document !== 'undefined') {
     window.addEventListener('DOMContentLoaded', () => {
-        const { host, token } = getSettings();
+        const { host, token, allowSelfSigned } = getSettings();
         const hostInput = document.getElementById('host');
         const tokenInput = document.getElementById('token');
+        const allowSelfSignedInput = document.getElementById('allowSelfSigned');
         if (hostInput) hostInput.value = host;
         if (tokenInput) tokenInput.value = token;
+        if (allowSelfSignedInput) allowSelfSignedInput.checked = allowSelfSigned;
         const saveBtn = document.getElementById('saveSettings');
         if (saveBtn) {
             saveBtn.addEventListener('click', () => {
-                setSettings({ host: hostInput.value, token: tokenInput.value });
+                setSettings({ host: hostInput.value, token: tokenInput.value, allowSelfSigned: allowSelfSignedInput.checked });
                 updateInfo();
             });
         }

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -15,13 +15,15 @@ global.localStorage = {
     return { json: async () => ({ ok: true }) };
   }
 
-  setSettings({ host: 'http://host', token: 'secret' });
+  setSettings({ host: 'http://host', token: 'secret', allowSelfSigned: true });
   const data = await fetchUnraidData('query { vars { version } }', dummyFetch);
 
   try {
     assert.deepStrictEqual(data, { ok: true });
     assert.strictEqual(captured.url, 'http://host/graphql');
     assert.strictEqual(captured.options.headers['Authorization'], 'Bearer secret');
+    assert.ok(captured.options.agent, 'agent should be passed when self-signed allowed');
+    assert.strictEqual(captured.options.agent.options.rejectUnauthorized, false);
     module.exports = true;
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- allow saving `allowSelfSigned` setting and expose checkbox in UI
- use HTTPS agent that ignores certificate errors in Node when enabled
- document the new capability in README and update current state in agents.md
- adjust settings test for the new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858184e91448332a4e5d0381e6e336a