### PR TITLE
Add Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY src/ /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ If your Unraid server uses a self-signed TLS certificate you can check the
 Node (for example during tests), this will disable certificate validation so the
 GraphQL requests succeed. Browsers still require you to manually trust the
 certificate the first time you connect.
+
+## Docker
+
+You can run the PWA using Docker which serves the static files via Nginx:
+
+```bash
+docker build -t unraid-pwa .
+docker run -d -p 8080:80 unraid-pwa
+```
+
+The application will then be available at `http://localhost:8080`.

--- a/agents.md
+++ b/agents.md
@@ -13,7 +13,7 @@ Rules to follow as an agent (please review each time):
 
 ## Current State
 
-The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option.
+The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option. A simple `Dockerfile` was added so the app can be served from an Unraid server using Nginx, avoiding CORS issues when hosted locally.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- add `Dockerfile` and `.dockerignore`
- document container usage in README
- record current Docker addition in agents log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aed3e13fc8332b66a0473382d8e26