### PR TITLE
Add DockerHub publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f package.json ]; then
+            npm ci || npm install
+          fi
+
+      - name: Run tests
+        run: npm test
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/unraid-pwa:latest

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ docker run -d -p 8080:80 unraid-pwa
 ```
 
 The application will then be available at `http://localhost:8080`.
+
+## CI/CD
+
+Pushes to the `main` branch trigger a GitHub Actions workflow that runs the test suite and then builds and publishes a Docker image. The image is pushed to Docker Hub using the account specified in the `DOCKERHUB_USERNAME` secret and is tagged as `latest`. A personal access token for that account should be stored in the `DOCKERHUB_TOKEN` secret.

--- a/agents.md
+++ b/agents.md
@@ -14,9 +14,11 @@ Rules to follow as an agent (please review each time):
 ## Current State
 
 The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option. A simple `Dockerfile` was added so the app can be served from an Unraid server using Nginx, avoiding CORS issues when hosted locally.
+A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
 ## Next Steps
 
 - Extend the UI to display more data from Unraid (array status, VMs, etc.).
 - Continue expanding test coverage for new features.
 - Investigate build tooling for production assets while maintaining static hosting.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and push Docker image
- document new workflow in README and agents.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b00c23cf48332a78fdf13324ac825