### PR TITLE
Fix Node ESM import in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The application lives in the `src` directory and is built using plain HTML and J
 npm test
 ```
 
+The tests run in Node's CommonJS environment and dynamically import the ES module
+from `src/main.js`.
+
 ## Project Structure
 
 - `src/index.html` – main entry point that registers the service worker.

--- a/agents.md
+++ b/agents.md
@@ -16,6 +16,8 @@ Rules to follow as an agent (please review each time):
 The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option. A simple `Dockerfile` was added so the app can be served from an Unraid server using Nginx, avoiding CORS issues when hosted locally.
 A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
+Tests were updated to load the ES module in `src/main.js` using dynamic import so they can run under Node's default CommonJS mode.
+
 ## Next Steps
 
 - Extend the UI to display more data from Unraid (array status, VMs, etc.).

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const { fetchUnraidData } = require('../src/main.js');
 
 async function dummyFetch() {
   return { json: async () => ({ ok: true }) };
 }
 
 (async () => {
+  const { fetchUnraidData } = await import('../src/main.js');
   try {
     assert.strictEqual(typeof fetchUnraidData, 'function', 'fetchUnraidData should be a function');
     const result = fetchUnraidData('query { version }', dummyFetch);

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { fetchUnraidData, setSettings } = require('../src/main.js');
 
 // minimal localStorage mock
 global.localStorage = {
@@ -9,6 +8,7 @@ global.localStorage = {
 };
 
 (async () => {
+  const { fetchUnraidData, setSettings } = await import('../src/main.js');
   let captured;
   async function dummyFetch(url, options) {
     captured = { url, options };


### PR DESCRIPTION
## Summary
- fix failing GitHub Actions tests by importing `src/main.js` as an ES module
- document how tests import ES modules in README
- update agents notes about the test update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7a781310833280e13b8f8f8c37f2