### PR TITLE
Add Node proxy server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,5 @@
-FROM nginx:alpine
-COPY src/ /usr/share/nginx/html/
+FROM node:20-alpine
+WORKDIR /app
+COPY src ./src
+COPY server ./server
+CMD ["node", "server/server.js"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ importing the module from `src/main.js`.
 - `src/sw.js` – service worker providing offline capabilities.
 - `src/manifest.json` – PWA manifest configuration.
 - `tests/` – simple assertion based tests run via Node.
+- `server/` – lightweight Node server used when running via Docker.
 
-The project is designed to be hosted on GitHub Pages without any server side components.
+The project can still be hosted on GitHub Pages without any server side components.
+A small Node server is provided for convenience when running in Docker.
 
 ## Usage
 
@@ -42,11 +44,13 @@ certificate the first time you connect.
 
 ## Docker
 
-You can run the PWA using Docker which serves the static files via Nginx:
+You can run the PWA using Docker which now starts a small Node server. The
+server serves the static files and proxies GraphQL requests to your Unraid
+instance, handling CSRF cookies automatically:
 
 ```bash
 docker build -t unraid-pwa .
-docker run -d -p 8080:80 unraid-pwa
+docker run -d -p 8080:3000 -e UNRAID_HOST=https://my-unraid unraid-pwa
 ```
 
 The application will then be available at `http://localhost:8080`.

--- a/agents.md
+++ b/agents.md
@@ -13,7 +13,7 @@ Rules to follow as an agent (please review each time):
 
 ## Current State
 
-The PWA now includes a small settings form allowing a host URL and API token to be stored in `localStorage`. An option also lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the new self-signed option. A simple `Dockerfile` was added so the app can be served from an Unraid server using Nginx, avoiding CORS issues when hosted locally.
+A small settings form allows a host URL and API token to be stored in `localStorage`. An option lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the self-signed option. A lightweight Node server now serves the static files and proxies GraphQL requests, handling CSRF cookies so the app can be hosted alongside an Unraid instance. Docker runs this server by default.
 A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
 `package.json` now declares the project as an ES module package. Tests were renamed with the `.cjs` extension so they continue to execute in CommonJS mode while dynamically importing `src/main.js`.
@@ -23,4 +23,5 @@ A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hu
 - Extend the UI to display more data from Unraid (array status, VMs, etc.).
 - Continue expanding test coverage for new features.
 - Investigate build tooling for production assets while maintaining static hosting.
+- Improve the proxy server and add more automated tests for it.
 

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "scripts": {
     "test": "node tests/run-tests.cjs"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,70 @@
+import express, { json as bodyParser, staticMiddleware } from './micro-express.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// factory to create the express application so tests can instantiate it
+export function createApp(fetchImpl = fetch) {
+  const app = express();
+
+  // Resolve directory of this file in ES module context
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  // Serve static files from ../src which contains the PWA assets
+  app.use(staticMiddleware(path.join(__dirname, '../src')));
+
+  app.use(bodyParser());
+
+  const UNRAID_HOST = process.env.UNRAID_HOST;
+  if (!UNRAID_HOST) {
+    throw new Error('UNRAID_HOST environment variable is required');
+  }
+  const UNRAID_TOKEN = process.env.UNRAID_TOKEN || '';
+
+  let cookies = '';
+  let csrfToken = '';
+
+  // Retrieve CSRF token and session cookie from the Unraid server
+  async function ensureCsrf() {
+    if (csrfToken) return;
+    const headers = { 'Content-Type': 'application/json' };
+    if (UNRAID_TOKEN) headers['Authorization'] = `Bearer ${UNRAID_TOKEN}`;
+    const res = await fetchImpl(`${UNRAID_HOST}/graphql`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: 'query { csrfToken }' })
+    });
+    const setCookie = res.headers.get('set-cookie');
+    if (setCookie) cookies = setCookie;
+    const data = await res.json();
+    csrfToken = data.data && data.data.csrfToken;
+  }
+
+  // Proxy incoming GraphQL requests to the Unraid server
+  app.post('/graphql', async (req, res) => {
+    try {
+      await ensureCsrf();
+      const headers = {
+        'Content-Type': 'application/json',
+        'Cookie': cookies,
+        'X-CSRF-TOKEN': csrfToken
+      };
+      // forward Authorization header from client or use default token
+      if (req.headers.authorization || UNRAID_TOKEN) {
+        headers['Authorization'] = req.headers.authorization || `Bearer ${UNRAID_TOKEN}`;
+      }
+      const upstream = await fetchImpl(`${UNRAID_HOST}/graphql`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(req.body)
+      });
+      const newCookie = upstream.headers.get('set-cookie');
+      if (newCookie) cookies = newCookie;
+      res.status(upstream.status);
+      res.set('Content-Type', 'application/json');
+      res.send(await upstream.text());
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return app;
+}

--- a/server/micro-express.js
+++ b/server/micro-express.js
@@ -1,0 +1,57 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+
+export default function express() {
+  const routes = { POST: {} };
+  const middleware = [];
+
+  function app(req, res) {
+    res.status = code => { res.statusCode = code; return res; };
+    res.set = (field, value) => { res.setHeader(field, value); return res; };
+    res.json = obj => { res.setHeader('Content-Type', 'application/json'); res.end(JSON.stringify(obj)); };
+    res.send = data => { if (typeof data === 'object') { res.setHeader('Content-Type', 'application/json'); data = JSON.stringify(data); } res.end(data); };
+    let i = 0;
+    function next(err) {
+      if (err) {
+        res.statusCode = 500;
+        return res.end(err.message);
+      }
+      const m = middleware[i++];
+      if (m) return m(req, res, next);
+      const handler = routes[req.method] && routes[req.method][req.url];
+      if (handler) return handler(req, res);
+      res.statusCode = 404;
+      res.end('Not Found');
+    }
+    next();
+  }
+
+  app.use = fn => middleware.push(fn);
+  app.post = (route, fn) => { routes.POST[route] = fn; };
+  app.listen = (port, cb) => http.createServer(app).listen(port, cb);
+  return app;
+}
+
+export function json() {
+  return (req, res, next) => {
+    let body = '';
+    req.on('data', c => body += c);
+    req.on('end', () => {
+      try { req.body = JSON.parse(body || '{}'); } catch { req.body = {}; }
+      next();
+    });
+  };
+}
+
+export function staticMiddleware(dir) {
+  return (req, res, next) => {
+    if (req.method !== 'GET') return next();
+    const file = req.url === '/' ? '/index.html' : req.url;
+    const filePath = path.join(dir, file);
+    fs.readFile(filePath, (err, data) => {
+      if (err) return next();
+      res.end(data);
+    });
+  };
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,7 @@
+import { createApp } from './index.js';
+
+const port = process.env.PORT || 3000;
+const app = createApp();
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/tests/server.test.cjs
+++ b/tests/server.test.cjs
@@ -1,0 +1,49 @@
+const http = require('http');
+const assert = require('assert');
+
+(async () => {
+  const { createApp } = await import('../server/index.js');
+
+  // create dummy upstream Unraid server
+  const upstream = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const { query } = JSON.parse(body);
+      if (query.includes('csrfToken')) {
+        res.setHeader('Set-Cookie', 'csrf=dummy');
+        res.end(JSON.stringify({ data: { csrfToken: 'dummy' } }));
+      } else if (req.headers.cookie === 'csrf=dummy' && req.headers['x-csrf-token'] === 'dummy') {
+        res.end(JSON.stringify({ data: { ok: true } }));
+      } else {
+        res.statusCode = 401;
+        res.end(JSON.stringify({ error: 'Invalid CSRF token' }));
+      }
+    });
+  });
+
+  await new Promise(resolve => upstream.listen(0, resolve));
+  const upstreamPort = upstream.address().port;
+  process.env.UNRAID_HOST = `http://localhost:${upstreamPort}`;
+
+  const app = createApp();
+  const server = app.listen(0, async () => {
+    const port = server.address().port;
+    try {
+      const res = await fetch(`http://localhost:${port}/graphql`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '{vars}' })
+      });
+      const data = await res.json();
+      assert.deepStrictEqual(data, { data: { ok: true } });
+      module.exports = true;
+    } catch (err) {
+      console.error(err);
+      module.exports = false;
+    } finally {
+      server.close();
+      upstream.close();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add lightweight Node/Express-style server to serve static files and proxy GraphQL requests
- implement custom micro-express to avoid dependencies
- provide server tests
- update Dockerfile to run Node server
- document new server in README and AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8c2d0ba08332b15a583083d3c181