### PR TITLE
Fix MIME type for static files and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ importing the module from `src/main.js`.
 - `tests/` – simple assertion based tests run via Node.
 - `server/` – lightweight Node server used when running via Docker.
 
+The server now sets proper MIME types for static assets so modern browsers can
+load ES module scripts without errors.
+
 The project can still be hosted on GitHub Pages without any server side components.
 A small Node server is provided for convenience when running in Docker.
 

--- a/agents.md
+++ b/agents.md
@@ -14,6 +14,7 @@ Rules to follow as an agent (please review each time):
 ## Current State
 
 A small settings form allows a host URL and API token to be stored in `localStorage`. An option lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the self-signed option. A lightweight Node server now serves the static files and proxies GraphQL requests, handling CSRF cookies so the app can be hosted alongside an Unraid instance. Docker runs this server by default.
+A recent update adds MIME type handling to this server so module scripts load correctly in the browser.
 A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
 `package.json` now declares the project as an ES module package. Tests were renamed with the `.cjs` extension so they continue to execute in CommonJS mode while dynamically importing `src/main.js`.

--- a/server/micro-express.js
+++ b/server/micro-express.js
@@ -45,12 +45,25 @@ export function json() {
 }
 
 export function staticMiddleware(dir) {
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.css': 'text/css',
+    '.wasm': 'application/wasm',
+    '.svg': 'image/svg+xml',
+    '.ico': 'image/x-icon'
+  };
+
   return (req, res, next) => {
     if (req.method !== 'GET') return next();
     const file = req.url === '/' ? '/index.html' : req.url;
     const filePath = path.join(dir, file);
     fs.readFile(filePath, (err, data) => {
       if (err) return next();
+      const ext = path.extname(filePath);
+      const type = mimeTypes[ext] || 'application/octet-stream';
+      res.setHeader('Content-Type', type);
       res.end(data);
     });
   };

--- a/tests/static.test.cjs
+++ b/tests/static.test.cjs
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const path = require('path');
+(async () => {
+  const { default: express, staticMiddleware } = await import('../server/micro-express.js');
+  const app = express();
+  app.use(staticMiddleware(path.join(__dirname, '../src')));
+  const server = app.listen(0, async () => {
+    const port = server.address().port;
+    try {
+      const res = await fetch(`http://localhost:${port}/main.js`);
+      const text = await res.text();
+      const fs = require('fs');
+      const original = fs.readFileSync(path.join(__dirname, '../src/main.js'), 'utf8');
+      assert.strictEqual(res.headers.get('content-type'), 'text/javascript');
+      assert.ok(text.includes('fetchUnraidData'), 'served file should contain script content');
+      assert.strictEqual(text.trim(), original.trim());
+      module.exports = true;
+    } catch (err) {
+      console.error(err);
+      module.exports = false;
+    } finally {
+      server.close();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- set appropriate Content-Type headers for static files
- add regression test for static middleware
- document MIME handling in README and agents.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d930a7c4c83329cda5466a94e0d08