### PR TITLE
Add self-signed TLS support for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Node (for example during tests), this will disable certificate validation so the
 GraphQL requests succeed. Browsers still require you to manually trust the
 certificate the first time you connect.
 
+When running the Docker proxy server you can achieve the same behaviour by
+setting the `ALLOW_SELF_SIGNED` environment variable to `true`. This will cause
+the server to ignore TLS validation errors when contacting your Unraid instance.
+
 ## Docker
 
 You can run the PWA using Docker which now starts a small Node server. The
@@ -53,7 +57,10 @@ instance, handling CSRF cookies automatically:
 
 ```bash
 docker build -t unraid-pwa .
-docker run -d -p 8080:3000 -e UNRAID_HOST=https://my-unraid unraid-pwa
+docker run -d -p 8080:3000 \
+  -e UNRAID_HOST=https://my-unraid \
+  -e ALLOW_SELF_SIGNED=true \
+  unraid-pwa
 ```
 
 The application will then be available at `http://localhost:8080`.

--- a/agents.md
+++ b/agents.md
@@ -14,7 +14,7 @@ Rules to follow as an agent (please review each time):
 ## Current State
 
 A small settings form allows a host URL and API token to be stored in `localStorage`. An option lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the self-signed option. A lightweight Node server now serves the static files and proxies GraphQL requests, handling CSRF cookies so the app can be hosted alongside an Unraid instance. Docker runs this server by default.
-A recent update adds MIME type handling to this server so module scripts load correctly in the browser.
+A recent update adds MIME type handling to this server so module scripts load correctly in the browser. The server can also skip TLS verification when `ALLOW_SELF_SIGNED=true` which helps when the Unraid instance uses a self-signed certificate. Proxy errors are now logged to aid debugging.
 A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
 `package.json` now declares the project as an ES module package. Tests were renamed with the `.cjs` extension so they continue to execute in CommonJS mode while dynamically importing `src/main.js`.
@@ -25,4 +25,5 @@ A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hu
 - Continue expanding test coverage for new features.
 - Investigate build tooling for production assets while maintaining static hosting.
 - Improve the proxy server and add more automated tests for it.
+- Ensure new self-signed handling is exercised by integration tests.
 

--- a/tests/server.selfsigned.test.cjs
+++ b/tests/server.selfsigned.test.cjs
@@ -1,0 +1,37 @@
+const assert = require('assert');
+
+(async () => {
+  const calls = [];
+  async function fakeFetch(url, opts) {
+    calls.push(opts);
+    return {
+      headers: { get: () => null },
+      json: async () => ({ data: { csrfToken: 'x' } }),
+      text: async () => JSON.stringify({ data: { ok: true } }),
+      status: 200
+    };
+  }
+  const { createApp } = await import('../server/index.js');
+  process.env.UNRAID_HOST = 'https://host';
+  process.env.ALLOW_SELF_SIGNED = 'true';
+  const app = createApp(fakeFetch);
+  const server = app.listen(0, async () => {
+    const port = server.address().port;
+    await fetch(`http://localhost:${port}/graphql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: '{vars}' })
+    });
+    try {
+      assert(calls[0].agent, 'agent should be provided for self-signed');
+      assert.strictEqual(calls[0].agent.options.rejectUnauthorized, false);
+      module.exports = true;
+    } catch (err) {
+      console.error(err);
+      module.exports = false;
+    } finally {
+      server.close();
+    }
+  });
+})();
+


### PR DESCRIPTION
## Summary
- add `ALLOW_SELF_SIGNED` env option to proxy server
- log proxy errors for easier debugging
- document new option in README and agents docs
- add test for self-signed behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d951f95e8833281db85f5c64afe38