### PR TITLE
Fix self-signed connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ certificate the first time you connect.
 
 When running the Docker proxy server you can achieve the same behaviour by
 setting the `ALLOW_SELF_SIGNED` environment variable to `true`. This will cause
-the server to ignore TLS validation errors when contacting your Unraid instance.
+the server to ignore TLS validation errors when contacting your Unraid instance
+by setting `NODE_TLS_REJECT_UNAUTHORIZED=0` internally.
 
 ## Docker
 

--- a/agents.md
+++ b/agents.md
@@ -14,7 +14,7 @@ Rules to follow as an agent (please review each time):
 ## Current State
 
 A small settings form allows a host URL and API token to be stored in `localStorage`. An option lets Node clients ignore TLS errors when using self-signed certificates. `main.js` exposes helpers for saving these values and for performing authenticated requests to the Unraid GraphQL endpoint. The page fetches and displays the server version as a basic example. Tests cover the settings logic including the self-signed option. A lightweight Node server now serves the static files and proxies GraphQL requests, handling CSRF cookies so the app can be hosted alongside an Unraid instance. Docker runs this server by default.
-A recent update adds MIME type handling to this server so module scripts load correctly in the browser. The server can also skip TLS verification when `ALLOW_SELF_SIGNED=true` which helps when the Unraid instance uses a self-signed certificate. Proxy errors are now logged to aid debugging.
+ A recent update adds MIME type handling to this server so module scripts load correctly in the browser. The server can also skip TLS verification when `ALLOW_SELF_SIGNED=true` by setting `NODE_TLS_REJECT_UNAUTHORIZED=0` which helps when the Unraid instance uses a self-signed certificate. Proxy errors are now logged to aid debugging.
 A GitHub Actions workflow runs tests and publishes the Docker image to Docker Hub on pushes to `main`.
 
 `package.json` now declares the project as an ES module package. Tests were renamed with the `.cjs` extension so they continue to execute in CommonJS mode while dynamically importing `src/main.js`.

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,12 @@ export function createApp(fetchImpl = fetch) {
   }
   const UNRAID_TOKEN = process.env.UNRAID_TOKEN || '';
   const ALLOW_SELF_SIGNED = process.env.ALLOW_SELF_SIGNED === 'true';
+
+  if (ALLOW_SELF_SIGNED && UNRAID_HOST.startsWith('https')) {
+    // instruct Node to allow self-signed certificates when contacting Unraid
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
   const httpsAgent = ALLOW_SELF_SIGNED && UNRAID_HOST.startsWith('https')
     ? new HttpsAgent({ rejectUnauthorized: false })
     : undefined;

--- a/tests/server.selfsigned.test.cjs
+++ b/tests/server.selfsigned.test.cjs
@@ -25,6 +25,7 @@ const assert = require('assert');
     try {
       assert(calls[0].agent, 'agent should be provided for self-signed');
       assert.strictEqual(calls[0].agent.options.rejectUnauthorized, false);
+      assert.strictEqual(process.env.NODE_TLS_REJECT_UNAUTHORIZED, '0');
       module.exports = true;
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- allow the proxy server to work with self-signed certs by setting `NODE_TLS_REJECT_UNAUTHORIZED=0`
- verify the env var in self-signed tests
- document behaviour in README and AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db4d118248332b2abe3f8fb390bd1